### PR TITLE
Use generate build config provider

### DIFF
--- a/src/main/groovy/com/sjcqs/android/config/ConfigPlugin.groovy
+++ b/src/main/groovy/com/sjcqs/android/config/ConfigPlugin.groovy
@@ -66,7 +66,7 @@ class ConfigPlugin implements Plugin<Project> {
         project.tasks.create(
                 name: "generate${variant.name.capitalize()}Settings",
                 type: GenerateSettingsTask) {
-            packageName variant.generateBuildConfig.buildConfigPackageName
+            packageName variant.getGenerateBuildConfigProvider().get().buildConfigPackageName
             flavorName variant.flavorName
             buildTypeName variant.buildType.name
             variantDirName variant.dirName


### PR DESCRIPTION
Fix #13

When using your library with AGP 7.0.0-alpha10 (corresponds to gradle
plugin with the same version) the project does not build.

https://android.googlesource.com/platform/tools/base/+/studio-master-dev/build-system/gradle-core/src/main/java/com/android/build/gradle/api/BaseVariant.java#290
```
    /**
     * Returns the BuildConfig generation task.
     *
     * @deprecated Use {@link #getGenerateBuildConfigProvider()}
     */
    @Nullable
    @Deprecated
    GenerateBuildConfig getGenerateBuildConfig();
    /**
     * Returns the {@link TaskProvider} for the BuildConfig generation task.
     *
     * <p>Prefer this to {@link #getGenerateBuildConfig()} as it triggers eager configuration of the
     * task.
     */
    @Nullable
    TaskProvider<GenerateBuildConfig> getGenerateBuildConfigProvider();
```

The `getGenerateBuildConfig` task is deprecated.
Documentation hints to use `getGenerateBuildConfigProvider` instead

### **How to test that ?**